### PR TITLE
Add .all function to return array of all rotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -47,14 +47,13 @@ console.log(beatles); // [ 'ringo', 'george', 'paul', 'john' ]
 
 ## rotate.all(array)
 
-Returns all rotations for the given array.
+Returns all rotations for the given array. It does not modify the passed in array.
 
 Example:
 
 ```js
 var beatles = ['paul', 'john', 'ringo', 'george'];
-var allRotations = rotate.all(beatles);
-console.log(allRotations);
+console.log(rotate.all(beatles));
 // [ [ 'paul', 'john', 'ringo', 'george' ],
 //   [ 'john', 'ringo', 'george', 'paul' ],
 //   [ 'ringo', 'george', 'paul', 'john' ],

--- a/README.md
+++ b/README.md
@@ -44,3 +44,19 @@ var beatles = ['paul', 'john', 'ringo', 'george'];
 rotate(beatles, 42);
 console.log(beatles); // [ 'ringo', 'george', 'paul', 'john' ]
 ```
+
+## rotate.all(array)
+
+Returns all rotations for the given array.
+
+Example:
+
+```js
+var beatles = ['paul', 'john', 'ringo', 'george'];
+var allRotations = rotate.all(beatles);
+console.log(allRotations);
+// [ [ 'paul', 'john', 'ringo', 'george' ],
+//   [ 'john', 'ringo', 'george', 'paul' ],
+//   [ 'ringo', 'george', 'paul', 'john' ],
+//   [ 'george', 'paul', 'john', 'ringo' ] ]
+```

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 'use strict';
 
-module.exports = function(array, num) {
+module.exports = rotate;
+
+function rotate(array, num) {
     num = (num || 0) % array.length;
     if (num < 0) {
         num += array.length;
@@ -8,4 +10,4 @@ module.exports = function(array, num) {
     var removed = array.splice(0, num);
     array.push.apply(array, removed);
     return array;
-};
+}

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 module.exports = rotate;
-
 function rotate(array, num) {
     num = (num || 0) % array.length;
     if (num < 0) {
@@ -10,4 +9,16 @@ function rotate(array, num) {
     var removed = array.splice(0, num);
     array.push.apply(array, removed);
     return array;
+}
+
+module.exports.all = all;
+function all(array) {
+    var clone = array.slice();
+    var rotations = [];
+    var n;
+    for (n = 0; n < clone.length; n++) {
+        rotations.push(clone.slice());
+        rotate(clone, 1);
+    }
+    return rotations;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rotate-array",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Rotates the elements of an array in place. Supports rotation in both directions and automatically wraps rotations which are larger than the input array size.",
   "main": "index.js",
   "scripts": {
@@ -19,9 +19,10 @@
   ],
   "author": "Christian Tegnér",
   "contributors": [
-    { "name" : "David Ernst",
-      "email" : "npm@dsernst.com",
-      "url" : "http://dsernst.com/"
+    {
+      "name": "David Ernst",
+      "email": "npm@dsernst.com",
+      "url": "http://dsernst.com/"
     }
   ],
   "license": "BSD-2-Clause",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,12 @@
     "rotate"
   ],
   "author": "Christian Tegnér",
+  "contributors": [
+    { "name" : "David Ernst",
+      "email" : "npm@dsernst.com",
+      "url" : "http://dsernst.com/"
+    }
+  ],
   "license": "BSD-2-Clause",
   "bugs": {
     "url": "https://github.com/CMTegner/rotate-array/issues"

--- a/test/array-rotate.js
+++ b/test/array-rotate.js
@@ -77,3 +77,16 @@ test('wraps when abs(negative num) greater than array size', function(t) {
     rotate(array, -12);
     t.same(array, ['boom', 'bang', 'baz', 'foo', 'bar']);
 });
+
+test('rotate.all returns every rotation', function(t) {
+    t.plan(1);
+
+    var array = [1, 2, 3, 4, 5];
+    t.same(rotate.all(array), [
+        [1, 2, 3, 4, 5],
+        [2, 3, 4, 5, 1],
+        [3, 4, 5, 1, 2],
+        [4, 5, 1, 2, 3],
+        [5, 1, 2, 3, 4]
+    ]);
+});


### PR DESCRIPTION
This adds an additional `.all` function, with jshint compliant code, a unit test, and usage documentation:

> ## rotate.all(array)
> 
> Returns all rotations for the given array. It does not modify the passed in array.
> 
> Example:
> 
> ``` js
> var beatles = ['paul', 'john', 'ringo', 'george'];
> console.log(rotate.all(beatles));
> // [ [ 'paul', 'john', 'ringo', 'george' ],
> //   [ 'john', 'ringo', 'george', 'paul' ],
> //   [ 'ringo', 'george', 'paul', 'john' ],
> //   [ 'george', 'paul', 'john', 'ringo' ] ]
> ```
