### PR TITLE
Wrap readme's <script> in backticks

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm i rotate-array
 ```
 
 ### Alternatives
-For usage via AMD / <script>, download a UMD bundle from [wzrd.in](http://wzrd.in/standalone/rotate-array@latest).
+For usage via AMD / `<script>`, download a UMD bundle from [wzrd.in](http://wzrd.in/standalone/rotate-array@latest).
 
 ## Usage
 


### PR DESCRIPTION
There's a problem rendering the readme on Github: it breaks as soon as it gets to the `<script>` tag. This PR fixes that by wrapping the tag in backticks.

Old: 

<img width="1134" alt="screen shot 2015-12-27 at 4 13 41 pm" src="https://cloud.githubusercontent.com/assets/6340841/12012686/3036eb0a-acb5-11e5-9b0d-8d66f6bfe155.png">

New:

<img width="1158" alt="screen shot 2015-12-27 at 4 16 38 pm" src="https://cloud.githubusercontent.com/assets/6340841/12012687/44859462-acb5-11e5-9b41-d42ddd7a09ca.png">
